### PR TITLE
Added DELETE endpoint for single record in MenuItemReview database table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -1,0 +1,94 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a REST controller for MenuItemReview
+ */
+
+@Tag(name = "MenuItemReview")
+@RequestMapping("/api/menuitemreview")
+@RestController
+@Slf4j
+public class MenuItemReviewController extends ApiController {
+
+    @Autowired
+    MenuItemReviewRepository menuItemReviewRepository;
+    
+    /**
+     * List all menu item reviews
+     * 
+     * @return an iterable of MenuItemReview
+     */
+    @Operation(summary= "List all menu item reviews")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<MenuItemReview> allMenuItemReviws() {
+        Iterable<MenuItemReview> reviews = menuItemReviewRepository.findAll();
+        return reviews;
+    }
+
+    /**
+     * Create a new menu item review
+     * 
+     * @param itemId the id of a menu item from UCSBDiningCommonsMenuItems
+     * @param reviewerEmail the email of the reviewer
+     * @param stars the rating in stars (0 to 5)
+     * @param dateReviewed the date reviewed
+     * @param comments the content of the review
+     * @return the saved menuitemreview
+     */
+    @Operation(summary= "Create a new menu item review")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public MenuItemReview postMenuItemReview(
+            @Parameter(name="itemId") @RequestParam long itemId,
+            @Parameter(name="reviewerEmail") @RequestParam String reviewerEmail,
+            @Parameter(name="stars") @RequestParam int stars,
+            @Parameter(name="dateReviewed", description="date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("dateReviewed") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateReviewed,
+            @Parameter(name="comments") @RequestParam String comments)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("dateReviewed={}", dateReviewed);
+
+        MenuItemReview menuItemReview = new MenuItemReview();
+        menuItemReview.setItemId(itemId);
+        menuItemReview.setReviewerEmail(reviewerEmail);
+        menuItemReview.setStars(stars);
+        menuItemReview.setDateReviewed(dateReviewed);
+        menuItemReview.setComments(comments);
+
+
+        MenuItemReview savedMenuItemReview = menuItemReviewRepository.save(menuItemReview);
+
+        return savedMenuItemReview;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -108,4 +108,32 @@ public class MenuItemReviewController extends ApiController {
 
         return savedMenuItemReview;
     }
+    
+    /**
+     * Update a single menu item review
+     * 
+     * @param id       id of the review to update
+     * @param incoming the new review
+     * @return the updated review object
+     */
+    @Operation(summary= "Update a single review")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public MenuItemReview updateMenuItemReview(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid MenuItemReview incoming) {
+
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        menuItemReview.setItemId(incoming.getItemId());
+        menuItemReview.setReviewerEmail(incoming.getReviewerEmail());
+        menuItemReview.setStars(incoming.getStars());
+        menuItemReview.setDateReviewed(incoming.getDateReviewed());
+        menuItemReview.setComments(incoming.getComments());
+
+        menuItemReviewRepository.save(menuItemReview);
+
+        return menuItemReview;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -54,6 +54,23 @@ public class MenuItemReviewController extends ApiController {
     }
 
     /**
+     * Get a single date by id
+     * 
+     * @param id the id of the review
+     * @return a MenuItemReview
+     */
+    @Operation(summary= "Get a single review")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public MenuItemReview getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        return menuItemReview;
+    }
+
+    /**
      * Create a new menu item review
      * 
      * @param itemId the id of a menu item from UCSBDiningCommonsMenuItems

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -108,6 +108,24 @@ public class MenuItemReviewController extends ApiController {
 
         return savedMenuItemReview;
     }
+
+    /**
+     * Delete a MenuItemReview
+     * 
+     * @param id the id of the review to delete
+     * @return a message indicating the review was deleted
+     */
+    @Operation(summary= "Delete a MenuItemReview")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteMenuItemReview(
+            @Parameter(name="id") @RequestParam Long id) {
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        menuItemReviewRepository.delete(menuItemReview);
+        return genericMessage("MenuItemReview with id %s deleted".formatted(id));
+    }
     
     /**
      * Update a single menu item review

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -76,6 +76,55 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
 
     @WithMockUser(roles = { "USER" })
     @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+            // arrange
+            LocalDateTime dR1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            MenuItemReview menuItemReview = MenuItemReview.builder()
+                            .itemId(7)
+                            .reviewerEmail("cgaucho3@ucsb.edu")
+                            .stars(5)
+                            .dateReviewed(dR1)
+                            .comments("Tastes good")
+                            .build();
+
+            when(menuItemReviewRepository.findById(eq(7L))).thenReturn(Optional.of(menuItemReview));
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/menuitemreview?id=7"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+            String expectedJson = mapper.writeValueAsString(menuItemReview);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+            // arrange
+
+            when(menuItemReviewRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/menuitemreview?id=7"))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+
+            verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("EntityNotFoundException", json.get("type"));
+            assertEquals("MenuItemReview with id 7 not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
     public void logged_in_user_can_get_all_menuitemreviews() throws Exception {
 
             // arrange

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -1,0 +1,148 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = MenuItemReviewController.class)
+@Import(TestConfig.class)
+public class MenuItemReviewControllerTests extends ControllerTestCase {
+
+    @MockBean
+    MenuItemReviewRepository menuItemReviewRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Authorization tests for /api/menuitemreview/all
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+            mockMvc.perform(get("/api/menuitemreview/all"))
+                            .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+            mockMvc.perform(get("/api/menuitemreview/all"))
+                            .andExpect(status().is(200)); // logged
+    }
+
+    // Authorization tests for /api/menuitemreview/post
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/menuitemreview/post"))
+                            .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/menuitemreview/post"))
+                            .andExpect(status().is(403)); // only admins can post
+    }
+
+    // // Tests with mocks for database actions
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_menuitemreviews() throws Exception {
+
+            // arrange
+            LocalDateTime dR1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                            .itemId(7)
+                            .reviewerEmail("cgaucho3@ucsb.edu")
+                            .stars(5)
+                            .dateReviewed(dR1)
+                            .comments("Tastes good")
+                            .build();
+
+            LocalDateTime dR2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+            MenuItemReview menuItemReview2 = MenuItemReview.builder()
+                            .itemId(6)
+                            .reviewerEmail("cgaucho2@ucsb.edu")
+                            .stars(2)
+                            .dateReviewed(dR2)
+                            .comments("Food sucks")
+                            .build();
+
+            ArrayList<MenuItemReview> expectedReviews = new ArrayList<>();
+            expectedReviews.addAll(Arrays.asList(menuItemReview1, menuItemReview2));
+
+            when(menuItemReviewRepository.findAll()).thenReturn(expectedReviews);
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/menuitemreview/all"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(menuItemReviewRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(expectedReviews);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_menuitemreview() throws Exception {
+            // arrange
+
+            LocalDateTime dR1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                            .itemId(7)
+                            .reviewerEmail("cgaucho3@ucsb.edu")
+                            .stars(5)
+                            .dateReviewed(dR1)
+                            .comments("Tastes good")
+                            .build();
+
+            when(menuItemReviewRepository.save(eq(menuItemReview1))).thenReturn(menuItemReview1);
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            post("/api/menuitemreview/post?itemId=7&reviewerEmail=cgaucho3@ucsb.edu&stars=5&dateReviewed=2022-01-03T00:00:00&comments=Tastes good")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(menuItemReviewRepository, times(1)).save(menuItemReview1);
+            String expectedJson = mapper.writeValueAsString(menuItemReview1);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -197,6 +197,57 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
 
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
+    public void admin_can_delete_a_menuitemreview() throws Exception {
+            // arrange
+
+            LocalDateTime dR1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            MenuItemReview menuItemReview1 = MenuItemReview.builder()
+                            .itemId(7)
+                            .reviewerEmail("cgaucho3@ucsb.edu")
+                            .stars(5)
+                            .dateReviewed(dR1)
+                            .comments("Tastes good")
+                            .build();
+
+            when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.of(menuItemReview1));
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/menuitemreview?id=15")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(menuItemReviewRepository, times(1)).findById(15L);
+            verify(menuItemReviewRepository, times(1)).delete(any());
+
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("MenuItemReview with id 15 deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_tries_to_delete_non_existent_menuitemreview_and_gets_right_error_message()
+                    throws Exception {
+            // arrange
+
+            when(menuItemReviewRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/menuitemreview?id=15")
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(menuItemReviewRepository, times(1)).findById(15L);
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("MenuItemReview with id 15 not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
     public void admin_can_edit_an_existing_menuitemreview() throws Exception {
             // arrange
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -194,4 +194,83 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
             String responseString = response.getResponse().getContentAsString();
             assertEquals(expectedJson, responseString);
     }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_edit_an_existing_menuitemreview() throws Exception {
+            // arrange
+
+            LocalDateTime dR1 = LocalDateTime.parse("2022-01-03T00:00:00");
+            LocalDateTime dR2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+            MenuItemReview menuItemReviewOrig = MenuItemReview.builder()
+                            .itemId(7)
+                            .reviewerEmail("cgaucho3@ucsb.edu")
+                            .stars(5)
+                            .dateReviewed(dR1)
+                            .comments("Tastes good")
+                            .build();
+
+            MenuItemReview menuItemReviewEdited = MenuItemReview.builder()
+                            .itemId(6)
+                            .reviewerEmail("cgaucho2@ucsb.edu")
+                            .stars(2)
+                            .dateReviewed(dR2)
+                            .comments("Food sucks")
+                            .build();
+
+            String requestBody = mapper.writeValueAsString(menuItemReviewEdited);
+
+            when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.of(menuItemReviewOrig));
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/menuitemreview?id=67")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("utf-8")
+                                            .content(requestBody)
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(menuItemReviewRepository, times(1)).findById(67L);
+            verify(menuItemReviewRepository, times(1)).save(menuItemReviewEdited); // should be saved with correct user
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(requestBody, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_cannot_edit_menuitemreview_that_does_not_exist() throws Exception {
+            // arrange
+
+            LocalDateTime dR1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            MenuItemReview menuItemReviewEdited = MenuItemReview.builder()
+                            .itemId(6)
+                            .reviewerEmail("cgaucho2@ucsb.edu")
+                            .stars(2)
+                            .dateReviewed(dR1)
+                            .comments("Food sucks")
+                            .build();
+
+            String requestBody = mapper.writeValueAsString(menuItemReviewEdited);
+
+            when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            put("/api/menuitemreview?id=67")
+                                            .contentType(MediaType.APPLICATION_JSON)
+                                            .characterEncoding("utf-8")
+                                            .content(requestBody)
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(menuItemReviewRepository, times(1)).findById(67L);
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("MenuItemReview with id 67 not found", json.get("message"));
+
+    }
 }


### PR DESCRIPTION
Added DELETE for a single record in MenuItemReviewController.java and tests for it in MenuItemReviewControllerTests.java. Works when used in Swagger locally and on dokku; passes jacoco:report and pitest:mutationCoverage.

Closes #30 