### PR TITLE
hienhuynh2026 - create database table for recommendation request

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/RecommendationRequest.java
@@ -1,0 +1,35 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a JPA entity that represents a UCSBDate, i.e. an entry
+ * that comes from the UCSB API for academic calendar dates.
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "RecommendationRequest")
+public class RecommendationRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String reuqesterEmail;
+  private String professorEmail;
+  private String explanation;
+  private LocalDateTime dataRequested;
+  private LocalDateTime dateNeeded;
+  private boolean done;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/RecommandationRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/RecommandationRequestRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The  is a RecommandationRequestRepository repository for RecommationRequest entities.
+ */
+
+@Repository
+public interface RecommandationRequestRepository extends CrudRepository<RecommendationRequest, Long> {
+ 
+}

--- a/src/main/resources/db/migration/changes/RecommendationRequest.json
+++ b/src/main/resources/db/migration/changes/RecommendationRequest.json
@@ -1,0 +1,80 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "RecommendationRequest-1",
+          "author": "hienhuynh2026",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "RECOMMENDATION_REQUEST"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "RECOMMENDATION_REQUEST_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUESTER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "PROFESSOR_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_REQUESTED",
+                      "type": "TIMESTAMP" 
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_NEEDED",
+                      "type": "TIMESTAMP" 
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DONE",
+                      "type": "BOOLEAN" 
+                    }
+                  }
+                ],
+                "tableName": "RECOMMENDATION_REQUEST"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Closes #20 

In this PR, we add a database table that represents the RecommendationRequest with the following fields:

```
String requesterEmail
String professorEmail
String explanation
LocalDateTime dateRequested
LocalDateTime dateNeeded
boolean done

```

You can test this by running the localhost and looking for the recommendation_request table on the h2-console:

<img width="148" alt="image" src="https://github.com/user-attachments/assets/f149a50b-0438-40f1-8b06-8474aa387382" />

You can also test this on dokku and connecting to the postgres database, and running \dt:

```
hienhuynh@dokku-05:~$ dokku postgres:connect team01-dev-hienhuynh2026-db
psql (15.2 (Debian 15.2-1.pgdg110+1))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

team01_dev_hienhuynh2026_db=# \dt
                 List of relations
 Schema |          Name          | Type  |  Owner   
--------+------------------------+-------+----------
 public | databasechangelog      | table | postgres
 public | databasechangeloglock  | table | postgres
 public | menuitemreview         | table | postgres
 public | recommendation_request | table | postgres
 public | restaurants            | table | postgres
 public | ucsbdates              | table | postgres
 public | ucsbdiningcommons      | table | postgres
 public | users                  | table | postgres
(8 rows)

team01_dev_hienhuynh2026_db=# 


```